### PR TITLE
Add ping sweep and HTTP title scanner modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ rdp = "0.12.8"
 
 # ssdp moudle scanner
 regex = "1.11.1"
+ipnet = "2.11.0"
 
 #camera uniview exploit
 quick-xml = "0.37.4"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ added uniview_nvr_pwd_disclosure
 added ssdp_msearch  
 added hearbleed  info leak from server saved to a bin file
 added port scanner  
+added ping_sweep network scanner
+added http_title_scanner
 added find command  
 updated docs  
 created docs  

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -163,7 +163,7 @@ Then:
 ```
 rsf> help
 rsf> modules
-rsf> use scanners/port_scanner
+rsf> use scanners/ping_sweep
 rsf> set target 192.168.0.1
 rsf> run
 ```

--- a/src/modules/scanners/http_title_scanner.rs
+++ b/src/modules/scanners/http_title_scanner.rs
@@ -1,0 +1,33 @@
+use anyhow::{Result, Context};
+use regex::Regex;
+use reqwest::Client;
+
+pub async fn run(target: &str) -> Result<()> {
+    run_interactive(target).await
+}
+
+pub async fn run_interactive(target: &str) -> Result<()> {
+    let client = Client::builder()
+        .redirect(reqwest::redirect::Policy::limited(5))
+        .build()
+        .context("Failed to build HTTP client")?;
+
+    let title_re = Regex::new(r"(?i)<title>(.*?)</title>")?;
+    for scheme in ["http", "https"] {
+        let url = format!("{}://{}", scheme, target);
+        match client.get(&url).send().await {
+            Ok(resp) => {
+                let text = resp.text().await.unwrap_or_default();
+                if let Some(cap) = title_re.captures(&text) {
+                    println!("[+] {} -> {}", url, cap.get(1).unwrap().as_str());
+                } else {
+                    println!("[+] {} -> <no title>", url);
+                }
+            }
+            Err(e) => {
+                println!("[-] Failed {}: {}", url, e);
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/modules/scanners/mod.rs
+++ b/src/modules/scanners/mod.rs
@@ -2,3 +2,5 @@ pub mod sample_scanner;
 pub mod ssdp_msearch;
 pub mod port_scanner;
 pub mod stalkroute_full_traceroute;
+pub mod http_title_scanner;
+pub mod ping_sweep;

--- a/src/modules/scanners/ping_sweep.rs
+++ b/src/modules/scanners/ping_sweep.rs
@@ -1,0 +1,42 @@
+use anyhow::{Result, Context};
+use ipnet::IpNet;
+use std::net::IpAddr;
+use std::sync::Arc;
+use tokio::{process::Command, sync::Semaphore, time::{timeout, Duration}};
+
+pub async fn run(target: &str) -> Result<()> {
+    run_interactive(target).await
+}
+
+pub async fn run_interactive(target: &str) -> Result<()> {
+    let net: IpNet = target.parse().context("Use CIDR notation like 192.168.1.0/24")?;
+    let hosts: Vec<IpAddr> = net.hosts().collect();
+    let semaphore = Arc::new(Semaphore::new(50));
+    let mut tasks = Vec::new();
+
+    for ip in hosts {
+        let sem = semaphore.clone();
+        let ip_str = ip.to_string();
+        tasks.push(tokio::spawn(async move {
+            let _permit = sem.acquire_owned().await.unwrap();
+            let cmd = if ip.is_ipv4() { "ping" } else { "ping6" };
+            let result = timeout(
+                Duration::from_secs(3),
+                Command::new(cmd)
+                    .args(["-c", "1", "-W", "1", &ip_str])
+                    .output(),
+            )
+            .await;
+            if let Ok(Ok(out)) = result {
+                if out.status.success() {
+                    println!("[+] Host {} is up", ip_str);
+                }
+            }
+        }));
+    }
+
+    for t in tasks {
+        let _ = t.await;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- implement new scanner modules for ping sweeps and grabbing HTTP titles
- register the new modules in scanner mod listing
- update README module list and docs example
- add `ipnet` dependency for network range handling

## Testing
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_685096e88bcc83238cd3f100fbdfca08